### PR TITLE
Create a directory for the shaders before compilation

### DIFF
--- a/assets/CMakeLists.txt
+++ b/assets/CMakeLists.txt
@@ -20,6 +20,7 @@ foreach(shader ${shader_files})
 	if (WIN32)
         add_custom_command(
             OUTPUT ${output_file}
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${output_dir}
             COMMAND ${Vulkan_GLSLANG_VALIDATOR} -V ${full_path} -o ${output_file}
             DEPENDS ${full_path}
         )


### PR DESCRIPTION
The first time you compile the project on windows the build fails because the shader compilation output directory does not exist.
![image](https://user-images.githubusercontent.com/10724392/89667778-9dc7ba00-d8d4-11ea-916d-f84811ff7eb0.png)

This line creates that directory.

