### PR TITLE
fix paths that don't have light contributions

### DIFF
--- a/assets/shaders/RayTracing.rgen
+++ b/assets/shaders/RayTracing.rgen
@@ -36,14 +36,16 @@ void main()
 		vec3 rayColor = vec3(1);
 
 		// Ray scatters are handled in this loop. There are no recursive traceNV() calls in other shaders.
-		for (uint b = 0; b < Camera.NumberOfBounces + 1; ++b)
+		for (uint b = 0; b <= Camera.NumberOfBounces; ++b)
 		{
 			const float tMin = 0.001;
 			const float tMax = 10000.0;
 
-			// If we've exceeded the ray bounce limit, no more light is gathered.
-			if (b == Camera.NumberOfBounces) {
-				rayColor *= vec3(0, 0, 0);
+			// If we've exceeded the ray bounce limit without hitting a light source, no light is gathered.
+			// Light emitting materials never scatter in this implementation, allowing us to make this logical shortcut.
+			if (b == Camera.NumberOfBounces) 
+			{
+				rayColor = vec3(0, 0, 0);
 				break;
 			}
 

--- a/assets/shaders/RayTracing.rgen
+++ b/assets/shaders/RayTracing.rgen
@@ -36,10 +36,16 @@ void main()
 		vec3 rayColor = vec3(1);
 
 		// Ray scatters are handled in this loop. There are no recursive traceNV() calls in other shaders.
-		for (uint b = 0; b < Camera.NumberOfBounces; ++b)
+		for (uint b = 0; b < Camera.NumberOfBounces + 1; ++b)
 		{
 			const float tMin = 0.001;
 			const float tMax = 10000.0;
+
+			// If we've exceeded the ray bounce limit, no more light is gathered.
+			if (b == Camera.NumberOfBounces) {
+				rayColor *= vec3(0, 0, 0);
+				break;
+			}
 
 			traceNV(
 				Scene, gl_RayFlagsOpaqueNV, 0xff, 


### PR DESCRIPTION
The problem:
Paths that do not hit a light are giving a contribution and they shouldn't. e.g If a path it's a wall and terminates if contribution should be zero however with the current code we get that the contribution of that path is the color of the material.
![RayTracer_ZpYY4fa9xa](https://user-images.githubusercontent.com/10724392/89687150-906ff700-d8f7-11ea-90c7-1f9f6a6ccf0c.png)
![RayTracer_jEFUi50fXy](https://user-images.githubusercontent.com/10724392/89687155-9239ba80-d8f7-11ea-8662-43347c3ba40b.png)

Solution:
if the path exceeds the max path length and it didn't get a contribution from a light, that path contribution is zero.

Path length 1:
![RayTracer_s8TXwAYCM6](https://user-images.githubusercontent.com/10724392/89687923-01fc7500-d8f9-11ea-9a53-95a2064506d7.png)
Path length 2:
![RayTracer_d63hwaYv3A](https://user-images.githubusercontent.com/10724392/89687938-058ffc00-d8f9-11ea-9e94-a3c1327aa838.png)
Path length 3:
![RayTracer_rDM4t4tPIe](https://user-images.githubusercontent.com/10724392/89687979-1c365300-d8f9-11ea-8ec1-4027a4efd40c.png)

And some samples gathered from the Ray Tracing: The Rest of Your Life
Path length 1:
![1bounce](https://user-images.githubusercontent.com/10724392/89688198-96ff6e00-d8f9-11ea-9fdc-62db7be18f75.png)
Path length 2:
![2bounces](https://user-images.githubusercontent.com/10724392/89688206-9e267c00-d8f9-11ea-80aa-8edfd1c18cf3.png)
Path length 3:
![3bounces](https://user-images.githubusercontent.com/10724392/89688212-9f57a900-d8f9-11ea-8a06-1245bbf71846.png)






