### PR TITLE
Do not force boost::stacktrace to use libbacktrace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,12 @@ if (UNIX)
 	
 	find_package(Backtrace REQUIRED)
 
+	string(COMPARE EQUAL ${Backtrace_HEADER} "backtrace.h" BacktraceRequired)
+
+	if (BacktraceRequired)
+		add_compile_definitions(BOOST_STACKTRACE_USE_BACKTRACE)
+	endif (BacktraceRequired)
+
 endif ()
 
 find_package(Boost REQUIRED COMPONENTS exception program_options) 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -166,7 +166,7 @@ add_executable(${exe_name}
 if (UNIX)
 	# GCC8 needs an extra lib for <filesystem>.
 	# This is not needed with GCC9 or higher.
-	set(extra_libs -lbacktrace -lstdc++fs)
+	set(extra_libs -lstdc++fs ${Backtrace_LIBRARIES})
 endif()
 
 set_target_properties(${exe_name} PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})

--- a/src/Utilities/Exception.hpp
+++ b/src/Utilities/Exception.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-#ifdef UNIX
-#define BOOST_STACKTRACE_USE_BACKTRACE
-#endif
 #include <boost/exception/all.hpp>
 #include <boost/stacktrace.hpp>
 #include <stdexcept>


### PR DESCRIPTION
Since boost::stracktrace may utilize backtrace functionality already available in newer libc, do not unconditionally set BOOST_STACKTRACE_USE_BACKTRACE if FindBacktrace.cmake module actually confirms the availability of backtrace().