### PR TITLE
Recreate swapchain on VK_SUBOPTIMAL_KHR

### DIFF
--- a/src/Vulkan/Application.cpp
+++ b/src/Vulkan/Application.cpp
@@ -172,7 +172,7 @@ void Application::DrawFrame()
 	uint32_t imageIndex;
 	auto result = vkAcquireNextImageKHR(device_->Handle(), swapChain_->Handle(), noTimeout, imageAvailableSemaphore, nullptr, &imageIndex);
 
-	if (result == VK_ERROR_OUT_OF_DATE_KHR || isWireFrame_ != graphicsPipeline_->IsWireFrame())
+	if (result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR || isWireFrame_ != graphicsPipeline_->IsWireFrame())
 	{
 		RecreateSwapChain();
 		return;
@@ -222,7 +222,7 @@ void Application::DrawFrame()
 
 	result = vkQueuePresentKHR(device_->PresentQueue(), &presentInfo);
 
-	if (result == VK_ERROR_OUT_OF_DATE_KHR)
+	if (result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR)
 	{
 		RecreateSwapChain();
 		return;


### PR DESCRIPTION
vkQueuePresentKHR can return VK_SUBOPTIMAL_KHR if the window size
changed. This should recreate the swapchain, like for
VK_ERROR_OUT_OF_DATE_KHR.