### PR TITLE
Default bounces

### DIFF
--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -67,5 +67,6 @@ Options::Options(const int argc, const char* argv[])
 	{
 		Throw(std::out_of_range("invalid present mode"));
 	}
+	DefaultBounces = vm["bounces"].defaulted();
 }
 

--- a/src/Options.hpp
+++ b/src/Options.hpp
@@ -31,6 +31,7 @@ public:
 	// Renderer options.
 	uint32_t Samples{};
 	uint32_t Bounces{};
+	bool DefaultBounces{};
 	uint32_t MaxSamples{};
 
 	// Window options

--- a/src/RayTracer.cpp
+++ b/src/RayTracer.cpp
@@ -117,6 +117,9 @@ void RayTracer::DrawFrame()
 		CreateSwapChain();
 		return;
 	}
+	
+	if (userSettings_.DefaultBounces)
+		userSettings_.NumberOfBounces = userSettings_.NumberOfDefaultBounces(userSettings_.SceneIndex);
 
 	// Check if the accumulation buffer needs to be reset.
 	if (resetAccumulation_ || 

--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -201,6 +201,7 @@ void UserInterface::DrawSettings()
 		ImGui::Checkbox("Accumulate rays between frames", &Settings().AccumulateRays);
 		uint32_t min = 1, max = 128;
 		ImGui::SliderScalar("Samples", ImGuiDataType_U32, &Settings().NumberOfSamples, &min, &max);
+		ImGui::Checkbox("Use Default Bounces", &Settings().DefaultBounces);
 		min = 1, max = 32;
 		ImGui::SliderScalar("Bounces", ImGuiDataType_U32, &Settings().NumberOfBounces, &min, &max);
 		ImGui::NewLine();

--- a/src/UserSettings.hpp
+++ b/src/UserSettings.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <array>
+
 struct UserSettings final
 {
 	// Application
@@ -15,6 +17,7 @@ struct UserSettings final
 	// Renderer
 	bool IsRayTraced;
 	bool AccumulateRays;
+	bool DefaultBounces;
 	uint32_t NumberOfSamples;
 	uint32_t NumberOfBounces;
 	uint32_t MaxNumberOfSamples;
@@ -34,6 +37,14 @@ struct UserSettings final
 
 	inline const static float FieldOfViewMinValue = 10.0f;
 	inline const static float FieldOfViewMaxValue = 90.0f;
+	
+	const int NumberOfDefaultBounces(unsigned int SceneIndex)
+	{
+		std::array<int,4> ArrayOfDefaultBounces= { 8, 8, 8, 16 };
+		if (SceneIndex >= ArrayOfDefaultBounces.size())
+			return 8;
+		return ArrayOfDefaultBounces.at(SceneIndex);
+	};
 
 	bool RequiresAccumulationReset(const UserSettings& prev) const
 	{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -103,6 +103,9 @@ namespace
 		userSettings.AccumulateRays = true;
 		userSettings.NumberOfSamples = options.Samples;
 		userSettings.NumberOfBounces = options.Bounces;
+		userSettings.DefaultBounces = options.DefaultBounces;
+		if (userSettings.DefaultBounces)
+			userSettings.NumberOfBounces = userSettings.NumberOfDefaultBounces(userSettings.SceneIndex);
 		userSettings.MaxNumberOfSamples = options.MaxSamples;
 
 		userSettings.ShowSettings = !options.Benchmark;


### PR DESCRIPTION
This branch introduces variable bounce numbers for different scenes. In nearly all scenes the amount of bounces can be reduced to 8 (or even lower), without a noticeable visual impact. Scene 3 is the only one having a lower bound of 16 Bounces.

This significantly improves performance (Benched on an RX 6800 (1440p, 8 Samples)):

| Number of Bounces                     | Scene 1 | Scene 2 | Scene 3 | Scene 4 | Scene 5 |
|---------------------------------------|---------|---------|---------|---------|---------|
| 8/8/16/8/8 Bounces (Proposed Default) | 45.6    | 45.2    | 17.6    | 51.8    | 18.4    |
| 16 Bounces (Current Default)          | 38.2    | 37.7    | 17.6    | 29.2    | 10.5    |
 

Images for Comparison:
Scene 1:
8 Bounces:
![1-8-Bounces](https://user-images.githubusercontent.com/6448982/109491069-69426800-7a89-11eb-95c1-b62d19d80ef2.PNG)
16 Bounces:
![1-16-Bounces](https://user-images.githubusercontent.com/6448982/109491076-6b0c2b80-7a89-11eb-9868-931a102fec9f.PNG)

Scene 3 (The visual artifavts can be seen on the glass wings):
8 Bounces:
![3-8-Bounces](https://user-images.githubusercontent.com/6448982/109491154-837c4600-7a89-11eb-87fd-b96ed956a85a.PNG)
12 Bounces:
![3-12-Bounces](https://user-images.githubusercontent.com/6448982/109491937-83c91100-7a8a-11eb-843a-ed41db5110e0.PNG)
16 Bounces:
![3-16-Bounces](https://user-images.githubusercontent.com/6448982/109491160-85460980-7a89-11eb-90af-28e3f04eb81b.PNG)

Scene 5;
8 Bounces:
![5-8-Bounces](https://user-images.githubusercontent.com/6448982/109493666-1cf92700-7a8d-11eb-864d-9b5c9d50124a.PNG)
16 Bounces:
![5-16-Bounces](https://user-images.githubusercontent.com/6448982/109493670-1e2a5400-7a8d-11eb-97ac-325c98dd4b21.PNG)
