### PR TITLE
Performance improvement: Change Ray dispatch

### DIFF
--- a/assets/shaders/RayTracing.rgen
+++ b/assets/shaders/RayTracing.rgen
@@ -25,69 +25,64 @@ void main()
 	// - pixel: we want the same random seed for each pixel to get a homogeneous anti-aliasing.
 	// - ray: we want a noisy random seed, different for each pixel.
 	uint pixelRandomSeed = Camera.RandomSeed;
-	Ray.RandomSeed = InitRandomSeed(InitRandomSeed(gl_LaunchIDEXT.x, gl_LaunchIDEXT.y), Camera.TotalNumberOfSamples);
+	Ray.RandomSeed = InitRandomSeed(InitRandomSeed(gl_LaunchIDEXT.x, gl_LaunchIDEXT.y),
+		InitRandomSeed(gl_LaunchIDEXT.z,Camera.TotalNumberOfSamples));
 
-	vec3 pixelColor = vec3(0);
+	//if (Camera.NumberOfSamples != Camera.TotalNumberOfSamples) break;
+	const vec2 pixel = vec2(gl_LaunchIDEXT.x + RandomFloat(pixelRandomSeed), gl_LaunchIDEXT.y + RandomFloat(pixelRandomSeed));
+	const vec2 uv = (pixel / gl_LaunchSizeEXT.xy) * 2.0 - 1.0;
 
-	// Accumulate all the rays for this pixels.
-	for (uint s = 0; s < Camera.NumberOfSamples; ++s)
+	vec2 offset = Camera.Aperture/2 * RandomInUnitDisk(Ray.RandomSeed);
+	vec4 origin = Camera.ModelViewInverse * vec4(offset, 0, 1);
+	vec4 target = Camera.ProjectionInverse * (vec4(uv.x, uv.y, 1, 1));
+	vec4 direction = Camera.ModelViewInverse * vec4(normalize(target.xyz * Camera.FocusDistance - vec3(offset, 0)), 0);
+	vec3 rayColor = vec3(1);
+
+	// Ray scatters are handled in this loop. There are no recursive traceRayEXT() calls in other shaders.
+	for (uint b = 0; b <= Camera.NumberOfBounces; ++b)
 	{
-		//if (Camera.NumberOfSamples != Camera.TotalNumberOfSamples) break;
-		const vec2 pixel = vec2(gl_LaunchIDEXT.x + RandomFloat(pixelRandomSeed), gl_LaunchIDEXT.y + RandomFloat(pixelRandomSeed));
-		const vec2 uv = (pixel / gl_LaunchSizeEXT.xy) * 2.0 - 1.0;
+		const float tMin = 0.001;
+		const float tMax = 10000.0;
 
-		vec2 offset = Camera.Aperture/2 * RandomInUnitDisk(Ray.RandomSeed);
-		vec4 origin = Camera.ModelViewInverse * vec4(offset, 0, 1);
-		vec4 target = Camera.ProjectionInverse * (vec4(uv.x, uv.y, 1, 1));
-		vec4 direction = Camera.ModelViewInverse * vec4(normalize(target.xyz * Camera.FocusDistance - vec3(offset, 0)), 0);
-		vec3 rayColor = vec3(1);
-
-		// Ray scatters are handled in this loop. There are no recursive traceRayEXT() calls in other shaders.
-		for (uint b = 0; b <= Camera.NumberOfBounces; ++b)
+		// If we've exceeded the ray bounce limit without hitting a light source, no light is gathered.
+		// Light emitting materials never scatter in this implementation, allowing us to make this logical shortcut.
+		if (b == Camera.NumberOfBounces) 
 		{
-			const float tMin = 0.001;
-			const float tMax = 10000.0;
-
-			// If we've exceeded the ray bounce limit without hitting a light source, no light is gathered.
-			// Light emitting materials never scatter in this implementation, allowing us to make this logical shortcut.
-			if (b == Camera.NumberOfBounces) 
-			{
-				rayColor = vec3(0, 0, 0);
-				break;
-			}
-
-			traceRayEXT(
-				Scene, gl_RayFlagsOpaqueEXT, 0xff, 
-				0 /*sbtRecordOffset*/, 0 /*sbtRecordStride*/, 0 /*missIndex*/, 
-				origin.xyz, tMin, direction.xyz, tMax, 0 /*payload*/);
-			
-			const vec3 hitColor = Ray.ColorAndDistance.rgb;
-			const float t = Ray.ColorAndDistance.w;
-			const bool isScattered = Ray.ScatterDirection.w > 0;
-
-			rayColor *= hitColor;
-
-			// Trace missed, or end of trace.
-			if (t < 0 || !isScattered)
-			{				
-				break;
-			}
-
-			// Trace hit.
-			origin = origin + t * direction;
-			direction = vec4(Ray.ScatterDirection.xyz, 0);
+			rayColor = vec3(0, 0, 0);
+			break;
 		}
 
-		pixelColor += rayColor;
-	}
+		traceRayEXT(
+			Scene, gl_RayFlagsOpaqueEXT, 0xff, 
+			0 /*sbtRecordOffset*/, 0 /*sbtRecordStride*/, 0 /*missIndex*/, 
+			origin.xyz, tMin, direction.xyz, tMax, 0 /*payload*/);
+		
+		const vec3 hitColor = Ray.ColorAndDistance.rgb;
+		const float t = Ray.ColorAndDistance.w;
+		const bool isScattered = Ray.ScatterDirection.w > 0;
 
-	const bool accumulate = Camera.NumberOfSamples != Camera.TotalNumberOfSamples;
-	const vec3 accumulatedColor = (accumulate ? imageLoad(AccumulationImage, ivec2(gl_LaunchIDEXT.xy)) : vec4(0)).rgb + pixelColor;
+		rayColor *= hitColor;
 
-	pixelColor = accumulatedColor / Camera.TotalNumberOfSamples;
+		// Trace missed, or end of trace.
+		if (t < 0 || !isScattered)
+		{				
+			break;
+		}
+
+		// Trace hit.
+		origin = origin + t * direction;
+		direction = vec4(Ray.ScatterDirection.xyz, 0);
+	} 
+
+	//Only reset the image on the first thread touching it.
+	const bool accumulate = Camera.NumberOfSamples != Camera.TotalNumberOfSamples
+		|| gl_LaunchIDEXT.z != 0;
+	const vec3 accumulatedColor = (accumulate ? imageLoad(AccumulationImage, ivec2(gl_LaunchIDEXT.xy)) : vec4(0)).rgb + rayColor;
+
+	rayColor = accumulate ? accumulatedColor / Camera.TotalNumberOfSamples : rayColor;
 
 	// Apply raytracing-in-one-weekend gamma correction.
-	pixelColor = sqrt(pixelColor);
+	rayColor = sqrt(rayColor);
 
 	if (Camera.ShowHeatmap)
 	{
@@ -95,9 +90,9 @@ void main()
 		const float heatmapScale = 1000000.0f * Camera.HeatmapScale * Camera.HeatmapScale;
 		const float deltaTimeScaled = clamp(float(deltaTime) / heatmapScale, 0.0f, 1.0f);
 
-		pixelColor = heatmap(deltaTimeScaled);
+		rayColor = heatmap(deltaTimeScaled);
 	}
 
 	imageStore(AccumulationImage, ivec2(gl_LaunchIDEXT.xy), vec4(accumulatedColor, 0));
-    imageStore(OutputImage, ivec2(gl_LaunchIDEXT.xy), vec4(pixelColor, 0));
+    imageStore(OutputImage, ivec2(gl_LaunchIDEXT.xy), vec4(rayColor, 0));
 }

--- a/assets/shaders/Scatter.glsl
+++ b/assets/shaders/Scatter.glsl
@@ -13,7 +13,7 @@ float Schlick(const float cosine, const float refractionIndex)
 RayPayload ScatterLambertian(const Material m, const vec3 direction, const vec3 normal, const vec2 texCoord, const float t, inout uint seed)
 {
 	const bool isScattered = dot(direction, normal) < 0;
-	const vec4 texColor = m.DiffuseTextureId >= 0 ? texture(TextureSamplers[m.DiffuseTextureId], texCoord) : vec4(1);
+	const vec4 texColor = m.DiffuseTextureId >= 0 ? texture(TextureSamplers[nonuniformEXT(m.DiffuseTextureId)], texCoord) : vec4(1);
 	const vec4 colorAndDistance = vec4(m.Diffuse.rgb * texColor.rgb, t);
 	const vec4 scatter = vec4(normal + RandomInUnitSphere(seed), isScattered ? 1 : 0);
 
@@ -26,7 +26,7 @@ RayPayload ScatterMetallic(const Material m, const vec3 direction, const vec3 no
 	const vec3 reflected = reflect(direction, normal);
 	const bool isScattered = dot(reflected, normal) > 0;
 
-	const vec4 texColor = m.DiffuseTextureId >= 0 ? texture(TextureSamplers[m.DiffuseTextureId], texCoord) : vec4(1);
+	const vec4 texColor = m.DiffuseTextureId >= 0 ? texture(TextureSamplers[nonuniformEXT(m.DiffuseTextureId)], texCoord) : vec4(1);
 	const vec4 colorAndDistance = isScattered ? vec4(m.Diffuse.rgb * texColor.rgb, t) : vec4(1, 1, 1, -1);
 	const vec4 scatter = vec4(reflected + m.Fuzziness*RandomInUnitSphere(seed), isScattered ? 1 : 0);
 
@@ -44,7 +44,7 @@ RayPayload ScatterDieletric(const Material m, const vec3 direction, const vec3 n
 	const vec3 refracted = refract(direction, outwardNormal, niOverNt);
 	const float reflectProb = refracted != vec3(0) ? Schlick(cosine, m.RefractionIndex) : 1;
 
-	const vec4 texColor = m.DiffuseTextureId >= 0 ? texture(TextureSamplers[m.DiffuseTextureId], texCoord) : vec4(1);
+	const vec4 texColor = m.DiffuseTextureId >= 0 ? texture(TextureSamplers[nonuniformEXT(m.DiffuseTextureId)], texCoord) : vec4(1);
 	
 	return RandomFloat(seed) < reflectProb
 		? RayPayload(vec4(texColor.rgb, t), vec4(reflect(direction, normal), 1), seed)

--- a/src/RayTracer.cpp
+++ b/src/RayTracer.cpp
@@ -151,7 +151,7 @@ void RayTracer::Render(VkCommandBuffer commandBuffer, const uint32_t imageIndex)
 
 	// Render the scene
 	userSettings_.IsRayTraced
-		? Vulkan::RayTracing::Application::Render(commandBuffer, imageIndex)
+		? Vulkan::RayTracing::Application::Render(commandBuffer, imageIndex, numberOfSamples_)
 		: Vulkan::Application::Render(commandBuffer, imageIndex);
 
 	// Render the UI

--- a/src/Vulkan/RayTracing/Application.cpp
+++ b/src/Vulkan/RayTracing/Application.cpp
@@ -208,8 +208,8 @@ void Application::Render(VkCommandBuffer commandBuffer, const uint32_t imageInde
 	VkStridedDeviceAddressRegionKHR callableShaderBindingTable = {};
 
 
-	uint32_t MaxRayDispatchSize = rayTracingProperties_->MaxRayDispatchInvocationCount();
-	uint32_t MaxRayDepth = MaxRayDispatchSize / (extent.width * extent.height);
+	const uint32_t MaxRayDispatchSize = rayTracingProperties_->MaxRayDispatchInvocationCount();
+	const uint32_t MaxRayDepth = MaxRayDispatchSize / (extent.width * extent.height);
 
 	// Execute ray tracing shaders.	
 	for (uint32_t SamplesRemaining = numberOfSamples; SamplesRemaining > 0;)

--- a/src/Vulkan/RayTracing/Application.hpp
+++ b/src/Vulkan/RayTracing/Application.hpp
@@ -35,7 +35,11 @@ namespace Vulkan::RayTracing
 		void DeleteAccelerationStructures();
 		void CreateSwapChain() override;
 		void DeleteSwapChain() override;
-		void Render(VkCommandBuffer commandBuffer, uint32_t imageIndex) override;
+		void Render(VkCommandBuffer commandBuffer, uint32_t imageIndex) override
+		{
+			Render(commandBuffer, imageIndex, 1);
+		};
+		void Render(VkCommandBuffer commandBuffer, uint32_t imageIndex, const uint32_t numberOfSamples);
 			   
 	private:
 

--- a/src/Vulkan/RayTracing/RayTracingProperties.hpp
+++ b/src/Vulkan/RayTracing/RayTracingProperties.hpp
@@ -20,6 +20,7 @@ namespace Vulkan
 			uint64_t MaxGeometryCount() const { return accelProps_.maxGeometryCount; }
 			uint64_t MaxInstanceCount() const { return accelProps_.maxInstanceCount; }
 			uint64_t MaxPrimitiveCount() const { return accelProps_.maxPrimitiveCount; }
+			uint32_t MaxRayDispatchInvocationCount() const { return pipelineProps_.maxRayDispatchInvocationCount; }
 			uint32_t MaxRayRecursionDepth() const { return pipelineProps_.maxRayRecursionDepth; }
 			uint32_t MaxShaderGroupStride() const { return pipelineProps_.maxShaderGroupStride; }
 			uint32_t MinAccelerationStructureScratchOffsetAlignment() const { return accelProps_.minAccelerationStructureScratchOffsetAlignment; }


### PR DESCRIPTION
This change improves rendering performance on an RX 6800 by 3-5%.
It changes the raytracing dispatches to only collect a single sample per ray generation shader invocation. This reduces the execution time of every wavefront and increases the amount of threads. This is done by dispatching threads in the z-direction.

| Dispatch | Samples | Scene 1 | Scene 2 | Scene 3 | Scene 4 | Scene 5 |
|----------|---------|---------|---------|---------|---------|---------|
| new      | 2       | 145.41  | 143.44  | 68.91   | 113.5   | 42.5    |
| old      | 2       | 140.04  | 138.45  | 66      | 108.66  | 40.16   |
| new      | 4       | 74.72   | 73.85   | 35.08   | 58.05   | 21.49   |
| old      | 4       | 72.63   | 71.73   | 33.98   | 55.86   | 20.43   |
| new      | 8       | 38.01   | 37.48   | 17.71   | 29.35   | 10.79   |
| old      | 8       | 36.83   | 36.49   | 17.27   | 28.32   | 10.33   |
| new      | 16      | 19.19   | 18.9    | 8.9     | 14.79   | 5.42    |
| old      | 16      | 18.66   | 18.47   | 8.73    | 14.29   | 5.22    |

Performance improvements with new dispatch compared to old.

| Samples | Scene 1 | Scene 2 | Scene 3 | Scene 4 | Scene 5 |
|---------|---------|---------|---------|---------|---------|
| 2       | 103.83% | 103.60% | 104.41% | 104.45% | 105.83% |
| 4       | 102.88% | 102.96% | 103.24% | 103.92% | 105.19% |
| 8       | 103.19% | 102.71% | 102.57% | 103.63% | 104.50% |
| 16      | 102.84% | 102.33% | 101.95% | 103.50% | 103.83% |