### PR TITLE
Check that devices support `VK_KHR_ray_tracing_pipeline`

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -216,19 +216,15 @@ namespace
 				return false;
 			}
 
-			// We want a device that supports the ray tracing extensions
-			uint32_t extensionPropertiesCount;
-			std::vector<VkExtensionProperties> extensionProperties;
-			vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionPropertiesCount, nullptr);
-			extensionProperties.resize(extensionPropertiesCount);
-			vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionPropertiesCount, extensionProperties.data());
-
-			const auto hasRayTracingPipelineExtension = std::find_if(extensionProperties.begin(), extensionProperties.end(), [](const VkExtensionProperties& extension)
+			// We want a device that supports the ray tracing extension.
+			const auto extensions = Vulkan::GetEnumerateVector(device, static_cast<const char*>(nullptr), vkEnumerateDeviceExtensionProperties);
+			const auto hasRayTracing = std::find_if(extensions.begin(), extensions.end(), [](const VkExtensionProperties& extension)
 			{
-				return strcmp(extension.extensionName, "VK_KHR_ray_tracing_pipeline") == 0;
+				return strcmp(extension.extensionName, VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME) == 0;
 			});
 
-			if (hasRayTracingPipelineExtension == extensionProperties.end()) {
+			if (hasRayTracing == extensions.end())
+			{
 				return false;
 			}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -216,6 +216,24 @@ namespace
 				return false;
 			}
 
+			uint32_t extensionPropertiesCount;
+			std::vector<VkExtensionProperties> extensionProperties;
+			vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionPropertiesCount, nullptr);
+			extensionProperties.resize(extensionPropertiesCount);
+			vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionPropertiesCount, extensionProperties.data());
+
+			const auto hasRayTracingPipelineExtension = std::find_if(extensionProperties.begin(), extensionProperties.end(), [](const VkExtensionProperties& extension)
+			{
+				return strcmp(extension.extensionName, "VK_KHR_ray_tracing_pipeline");
+			});
+
+			if (hasRayTracingPipelineExtension == extensionProperties.end()) {
+				return false;
+			}
+
+			// We want a device that supports the ray tracing extensions
+			//const auto vec = Vulkan::GetEnumerateVector(device, vkEnumerateDeviceExtensionProperties);
+
 			// We want a device with a graphics queue.
 			const auto queueFamilies = Vulkan::GetEnumerateVector(device, vkGetPhysicalDeviceQueueFamilyProperties);
 			const auto hasGraphicsQueue = std::find_if(queueFamilies.begin(), queueFamilies.end(), [](const VkQueueFamilyProperties& queueFamily)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -216,6 +216,7 @@ namespace
 				return false;
 			}
 
+			// We want a device that supports the ray tracing extensions
 			uint32_t extensionPropertiesCount;
 			std::vector<VkExtensionProperties> extensionProperties;
 			vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionPropertiesCount, nullptr);
@@ -230,9 +231,6 @@ namespace
 			if (hasRayTracingPipelineExtension == extensionProperties.end()) {
 				return false;
 			}
-
-			// We want a device that supports the ray tracing extensions
-			//const auto vec = Vulkan::GetEnumerateVector(device, vkEnumerateDeviceExtensionProperties);
 
 			// We want a device with a graphics queue.
 			const auto queueFamilies = Vulkan::GetEnumerateVector(device, vkGetPhysicalDeviceQueueFamilyProperties);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -225,7 +225,7 @@ namespace
 
 			const auto hasRayTracingPipelineExtension = std::find_if(extensionProperties.begin(), extensionProperties.end(), [](const VkExtensionProperties& extension)
 			{
-				return strcmp(extension.extensionName, "VK_KHR_ray_tracing_pipeline");
+				return strcmp(extension.extensionName, "VK_KHR_ray_tracing_pipeline") == 0;
 			});
 
 			if (hasRayTracingPipelineExtension == extensionProperties.end()) {


### PR DESCRIPTION
I've been playing with this with my external GPU and it's very impressive, but at first I wasn't able to get it to work because it was selecting my internal GPU instead. This PR makes sure that it selects a device with the `VK_KHR_ray_tracing_pipeline` extension. The other way to do things would be to have a command line option to select the index of the GPU to be used.