### PR TITLE
Target Visual Studio 2022.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       SDK_VERSION: 1.2.189.2
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ First you will need to install the [Vulkan SDK](https://vulkan.lunarg.com/sdk/ho
 
 If in doubt, please check the GitHub Actions [continuous integration configurations](.github/workflows) for more details.
 
-**Windows (Visual Studio 2019 x64 solution)** [![Windows CI Status](https://github.com/GPSnoopy/RayTracingInVulkan/workflows/Windows%20CI/badge.svg)](https://github.com/GPSnoopy/RayTracingInVulkan/actions?query=workflow%3A%22Windows+CI%22)
+**Windows (Visual Studio 2022 x64 solution)** [![Windows CI Status](https://github.com/GPSnoopy/RayTracingInVulkan/workflows/Windows%20CI/badge.svg)](https://github.com/GPSnoopy/RayTracingInVulkan/actions?query=workflow%3A%22Windows+CI%22)
 ```
 vcpkg_windows.bat
 build_windows.bat

--- a/build_windows.bat
+++ b/build_windows.bat
@@ -1,7 +1,7 @@
 cd build || goto :error
 mkdir windows || goto :error
 cd windows || goto :error
-cmake -D VCPKG_TARGET_TRIPLET=x64-windows-static -D CMAKE_TOOLCHAIN_FILE=../vcpkg.windows/scripts/buildsystems/vcpkg.cmake -G "Visual Studio 16 2019" -A "x64" ../.. || goto :error
+cmake -D VCPKG_TARGET_TRIPLET=x64-windows-static -D CMAKE_TOOLCHAIN_FILE=../vcpkg.windows/scripts/buildsystems/vcpkg.cmake -G "Visual Studio 17 2022" -A "x64" ../.. || goto :error
 msbuild RayTracingInVulkan.sln /t:Rebuild /p:Configuration=Release || goto :error
 cd ..
 cd ..

--- a/vcpkg_linux.sh
+++ b/vcpkg_linux.sh
@@ -5,7 +5,8 @@ mkdir -p build
 cd build
 git clone https://github.com/Microsoft/vcpkg.git vcpkg.linux
 cd vcpkg.linux
-git checkout 2021.05.12
+# vcpkg 2021-11-30 23:20 UTC
+git checkout ed74ff32c6a859b6b9a96f1ee028dcfcae184a26
 ./bootstrap-vcpkg.sh
 
 ./vcpkg install \

--- a/vcpkg_windows.bat
+++ b/vcpkg_windows.bat
@@ -2,7 +2,8 @@ mkdir build
 cd build || goto :error
 git clone https://github.com/Microsoft/vcpkg.git vcpkg.windows || goto :error
 cd vcpkg.windows || goto :error
-git checkout 2021.05.12 || goto :error
+REM vcpkg 2021-11-30 23:20 UTC
+git checkout ed74ff32c6a859b6b9a96f1ee028dcfcae184a26 || goto :error
 call bootstrap-vcpkg.bat || goto :error
 
 vcpkg.exe install ^


### PR DESCRIPTION
Use vcpkg release recent enough to know about VS2022 (doesn't work otherwise, claims to find no suitable VS install)