### PR TITLE
Replaced std::find_if to std::any_of in few places

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -234,24 +234,24 @@ namespace
 
 			// We want a device that supports the ray tracing extension.
 			const auto extensions = Vulkan::GetEnumerateVector(device, static_cast<const char*>(nullptr), vkEnumerateDeviceExtensionProperties);
-			const auto hasRayTracing = std::find_if(extensions.begin(), extensions.end(), [](const VkExtensionProperties& extension)
+			const auto hasRayTracing = std::any_of(extensions.begin(), extensions.end(), [](const VkExtensionProperties& extension)
 			{
 				return strcmp(extension.extensionName, VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME) == 0;
 			});
 
-			if (hasRayTracing == extensions.end())
+			if (!hasRayTracing)
 			{
 				return false;
 			}
 
 			// We want a device with a graphics queue.
 			const auto queueFamilies = Vulkan::GetEnumerateVector(device, vkGetPhysicalDeviceQueueFamilyProperties);
-			const auto hasGraphicsQueue = std::find_if(queueFamilies.begin(), queueFamilies.end(), [](const VkQueueFamilyProperties& queueFamily)
+			const auto hasGraphicsQueue = std::any_of(queueFamilies.begin(), queueFamilies.end(), [](const VkQueueFamilyProperties& queueFamily)
 			{
 				return queueFamily.queueCount > 0 && queueFamily.queueFlags & VK_QUEUE_GRAPHICS_BIT;
 			});
 
-			return hasGraphicsQueue != queueFamilies.end();
+			return hasGraphicsQueue;
 		});
 
 		if (result == physicalDevices.end())


### PR DESCRIPTION
It looks like this would make code more readable: don't need to use iterators in if few lines below, and variable names `has**` now reflect variable content more.

IDK if this change makes any sense. I am not C++ dev, but perhaps this would be beneficial. 