### PR TITLE
Modify linux build scripts to try to pick up correct arch

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -1,7 +1,28 @@
 #!/bin/sh
 set -e
 
+arch=$(uname -m)
+vcpkg_arch=""
+case ${arch} in
+	"aarch64")
+		vcpkg_arch="arm64"
+		if [ -z ${VCPKG_FORCE_SYSTEM_BINARIES} ]; then
+			echo "VCPKG_FORCE_SYSTEM_BINARIES must be set to 1 on aarch64!"
+			exit 1
+		fi
+		;;
+	"x86_64")
+		vcpkg_arch="x64"
+		;;
+	*)
+		echo "Please check the mapping for 'uname -m' output to vcpkg expected arch"
+		exit 1
+		;;
+esac
+
+nproc=$(nproc || echo 4)
+
 mkdir --parents build/linux
 cd build/linux
-cmake -D CMAKE_BUILD_TYPE=Release -D VCPKG_TARGET_TRIPLET=x64-linux -D CMAKE_TOOLCHAIN_FILE=../vcpkg.linux/scripts/buildsystems/vcpkg.cmake ../..
-make -j
+cmake -D Boost_NO_SYSTEM_PATHS=ON -D CMAKE_BUILD_TYPE=Release -D VCPKG_TARGET_TRIPLET="${vcpkg_arch}-linux" -D CMAKE_TOOLCHAIN_FILE=../vcpkg.linux/scripts/buildsystems/vcpkg.cmake ../..
+make -j${nproc}

--- a/vcpkg_linux.sh
+++ b/vcpkg_linux.sh
@@ -1,6 +1,25 @@
 #!/bin/bash
 set -e
 
+arch=$(uname -m)
+vcpkg_arch=""
+case ${arch} in
+	"aarch64")
+		vcpkg_arch="arm64"
+		if [ -z ${VCPKG_FORCE_SYSTEM_BINARIES} ]; then
+			echo "VCPKG_FORCE_SYSTEM_BINARIES must be set to 1 on aarch64!"
+			exit 1
+		fi
+		;;
+	"x86_64")
+		vcpkg_arch="x64"
+		;;
+	*)
+		echo "Please check the mapping for 'uname -m' output to vcpkg expected arch"
+		exit 1
+		;;
+esac
+
 mkdir -p build
 cd build
 git clone https://github.com/Microsoft/vcpkg.git vcpkg.linux
@@ -9,11 +28,11 @@ git checkout 2024.03.25
 ./bootstrap-vcpkg.sh
 
 ./vcpkg install \
-	boost-exception:x64-linux \
-	boost-program-options:x64-linux \
-	boost-stacktrace:x64-linux \
-	glfw3:x64-linux \
-	glm:x64-linux \
-	imgui[core,freetype,glfw-binding,vulkan-binding]:x64-linux \
-	stb:x64-linux \
-	tinyobjloader:x64-linux
+	boost-exception:${vcpkg_arch}-linux \
+	boost-program-options:${vcpkg_arch}-linux \
+	boost-stacktrace:${vcpkg_arch}-linux \
+	glfw3:${vcpkg_arch}-linux \
+	glm:${vcpkg_arch}-linux \
+	imgui[core,freetype,glfw-binding,vulkan-binding]:${vcpkg_arch}-linux \
+	stb:${vcpkg_arch}-linux \
+	tinyobjloader:${vcpkg_arch}-linux


### PR DESCRIPTION
Based on system status, pick up correct arch.

For vcpkg mapping that I figured out is as following:
 * x86_64 -> x64
 * aarch64 -> arm64

So a simple case could take of that and save a bit of time for people who are first time compiling RayTracingInVulkan.

Fixes #81 81